### PR TITLE
feat: 基于 AntV/G DOM 模型从零重写 GE 图编辑器（8 shape / 19 插件 / X6 抽象层 / React）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,6 +542,28 @@ layout: { name: 'absolute', args: { x: 10, y: 20 } }
 
 **GE 应尽可能模仿浏览器原生 API。**
 
+#### 数据结构 vs API 的明确决策
+
+- **数据结构**：借鉴 X6（Markup/Selector/Attrs/shape 声明式模型、Cell props）
+- **交互 API**：靠拢 DOM（`setAttribute` / `appendChild` / `addEventListener` / `classList` / `querySelector`）
+
+不用 X6 的命令式 API（`addNode/addTools/graph.on`），用 DOM 标准 API：
+
+| 操作 | ❌ X6 命令式 | ✅ GE DOM 化 |
+|------|------------|-------------|
+| 创建节点 | `graph.addNode({shape,x,y})` | `graph.appendChild(new Node({shape,x,y}))` |
+| 删除 | `graph.removeNode(id)` | `graph.removeChild(node)` |
+| 变换 | `node.resize(w,h)` / `node.rotate(a)` | `node.setAttribute('width',w)` / `setAttribute('angle',a)` |
+| 工具 | `node.addTools(['resize','rotate'])` | `node.setAttribute('resizable',true)` / `setAttribute('rotatable',true)` |
+| 端口 | `node.addPort({id})` | `node.appendChild(new Port({id}))` |
+| 事件 | `graph.on('node:click',fn)` | `graph.addEventListener('node:click',fn)`（事件冒泡） |
+| 属性访问 | `cell.prop('body/fill','#f00')` | `node.getSubElement('body').setAttribute('fill','#f00')` |
+| 序列化 | `cell.toJSON()` | `node.props`（attribute 自动同步）/ `graph.toJSON()` |
+
+**Model = attribute/props**，不独立 Model 类。CustomElement 的 attribute 即模型，`attributeChangedCallback` 即变更监听。
+
+**工具系统声明式**：`setAttribute('resizable'/'rotatable')` 配置，选中时插件读 attribute 渲染手柄。不用 `addTools()` 命令式挂载。
+
 由于 `@antv/g-lite` 已经模拟了 DOM API，GE 的交互系统也应该模拟浏览器内置 API。这确保了：
 
 1. **开发者知识直接迁移** - 现有的浏览器 API 立即可用

--- a/README.md
+++ b/README.md
@@ -2,159 +2,59 @@
 
 > GE = g-lite DOM 模型 + 图编辑领域语义。把 [AntV/G](https://g.antv.antgroup.com/) 当作「浏览器引擎」，GE 是跑在它之上的「图编辑 DOM 规范」——就像 HTML 之于浏览器。
 
-本仓库的 `rewrite` 分支为**从零重写**版本：以 g-lite 的 CustomElement / Document 为唯一基座，不再重建任何平行系统。
+## 设计哲学
 
----
+- **数据结构**：借鉴 X6（Markup/Selector/Attrs/shape 声明式模型）
+- **交互 API**：靠拢 DOM（`setAttribute` / `appendChild` / `addEventListener` / `classList` / `querySelector`）
+
+```ts
+// 创建（DOM 风格）
+graph.appendChild(new Node({ shape: 'rect', x: 100, y: 100, label: 'A' }));
+
+// 变换（attribute 驱动）
+node.setAttribute('angle', 45);        // 旋转
+node.setAttribute('width', 200);       // 缩放
+node.setAttribute('resizable', true);  // 声明式工具配置
+
+// 查询（document API）
+graph.getElementById('n1');
+graph.querySelector('.selected');
+
+// 事件（DOM 冒泡）
+node.addEventListener('click', fn);
+graph.addEventListener('node:dragend', fn);
+```
 
 ## 核心特性
 
-- **真正的类 DOM API**：`appendChild / getElementById / getElementsByClassName / addEventListener / connectedCallback` 全部直接来自 g-lite。
-- **Web Components 心智**：领域元素 = 领域特化的 `CustomElement`，`attributeChangedCallback` 做响应式，`className` 做类型识别。
-- **X6 式抽象层**：`ShapeRegistry`（shape 可注册：rect/circle/ellipse/diamond/自定义）+ `Markup/Selector`（声明式子元素 + `getSubElement(selector)` 寻址）+ `Attrs`（selector 粒度 `stateStyles`）+ `Model`（完整 props 序列化，不漏字段）。
-- **统一锚点模块**：Node/Port/Edge 共用唯一的 Anchor 类型源与注册表。
-- **边原地更新**：Router/Connector 计算路径后 `setAttribute('d', ...)` 原地写回 Path，不销毁重建。
-- **边视觉**：终点方向箭头（marker，尖端贴 target 边缘）+ 边标签（自动定位路径中点）+ 边路径控制点编辑（双击添加 waypoint，拖拽调整）。
-- **事件驱动联动**：节点移动派发 `node:boundschange`，相连边监听后自动重算路径。
-- **渲染引擎可插拔**：默认 `g-svg`（每图形即真实 DOM 元素，便于 querySelector 检视/自动化验证），大图可切 `renderer: 'canvas'`。
-- **交互编辑**：`Drag` / `Resize`（选中节点拖角改尺寸）/ `Selection` / `Hover` / `CreateEdge` / `Vertex`（边路径控制点）/ `Keyboard` / `Clipboard` / `Transform`（多选变换）/ `History` / `Scroller`（缩放·平移）/ `Snapline` / `Group embedding`。
-- **坐标变换（pan/zoom）**：GE 自有 2D 坐标层（panOffset + 中心缩放公式），pan 用 `root.translate`、zoom 用 `camera.setZoom`，坐标转换与渲染完全一致。自定义 `pickNode` 命中（不依赖 g-lite 3D 投影）。
-- **状态样式可配置**：交互状态通过 `className` 触发，样式由 `stateStyles` 按 selector 粒度配置。
-- **数据能力**：`toJSON/fromJSON`（完整序列化）/ `toDataURL`（PNG 导出）/ `MinimapPlugin`（拖框导航 + 实时预览）。
-- **自动布局**：`gridLayout` / `circularLayout` / `forceLayout`（力导向 FR）/ `hierarchicalLayout`（DAG 分层），`graph.applyLayout()`。
-- **拖拽创建**：`DndPlugin` + Stencil 面板，放置后 DOM 校准确保 pan/zoom 后精确对齐鼠标位置。
-- **框架封装**：`@antv/ge-react` 声明式 `<GraphView>`（props 变化自动 diff 同步：增/删/改）。
-
-## 架构分层
-
-```
-Layer 4  框架适配  @antv/ge-react（声明式 GraphView + diff）
-Layer 3  插件工具  Drag/Resize/Selection/Hover/CreateEdge/Vertex/Keyboard/Clipboard/Transform/History/Scroller/Snapline/Dnd/Minimap
-Layer 2  核心包    @antv/ge-core
-         ├─ 领域元素  Cell → Node/Edge/Port/Group（extends CustomElement）
-         ├─ X6 抽象   ShapeRegistry / Markup+Selector / Attrs / Model
-         ├─ 原语      Anchor / Router / Connector（纯函数 + 注册表）
-         └─ 图容器    Graph extends Canvas（panOffset + 2D 坐标层）
-Layer 1  渲染引擎  @antv/g-lite（不改）
-```
+- **类 DOM API**：`appendChild / getElementById / addEventListener / connectedCallback` 直接来自 g-lite。
+- **X6 式抽象**：ShapeRegistry + Markup/Selector + Attrs(selector 粒度) + Model(props 序列化)。
+- **8 个内置 shape**：rect / circle / ellipse / diamond / triangle / hexagon / parallelogram / cylinder。
+- **19 个插件**：Drag / Resize(8向) / Rotate / Selection(框选) / Hover / CreateEdge / Vertex(增删) / Keyboard / Clipboard / Transform / History(snapshot) / Scroller / Snapline / Group(嵌套) / Dnd(坐标校准) / Minimap(拖框导航) / Grid(背景网格) / ContextMenu / Tooltip。
+- **边视觉**：双向箭头(startArrow) / 标签(distance 沿路径定位) / Router(normal/orthogonal/manhattan) / Connector(normal/rounded/smooth)。
+- **坐标变换**：GE 自有 2D 坐标层（panOffset + 中心缩放），pan/zoom 后坐标转换与渲染完全一致。
+- **React 封装**：`@antv/ge-react` 声明式 `<GraphView>`（props diff 自动同步）。
 
 ## 快速开始
 
 ```bash
-pnpm install          # 安装依赖
-pnpm dev              # 启动 Vite，打开 examples
-pnpm test             # 运行单元测试（Vitest）
-pnpm build            # 构建包（tsup）
+pnpm install && pnpm dev    # 启动 examples
+pnpm test                    # 75 单测
+pnpm build                   # 构建
 ```
 
-### 最小示例
-
-```ts
-import { Graph } from '@ge';
-
-const graph = new Graph({ container: '#app', background: '#fafafa' });
-await graph.ready;
-
-graph.addNode({ id: 'a', x: 80, y: 140, width: 130, height: 50, label: 'Start' });
-graph.addNode({ id: 'b', x: 360, y: 80, width: 130, height: 50, label: 'Process' });
-
-// 边自动用 perimeter 锚点从节点「边缘」连接，并经 router/connector 路由
-graph.addEdge({ source: 'a', target: 'b', router: 'orthogonal', connector: 'rounded' });
-
-// 查询走 g-lite document API，无平行 Map
-graph.getNode('a');     // getElementById
-graph.getNodes();       // getElementsByClassName('ge-node')
-```
-
-### 声明式自定义节点（X6 式 Markup）
-
-```ts
-graph.shapes.register({
-  name: 'card',
-  markup: [
-    { tagName: 'rect', selector: 'body', attrs: { width: 140, height: 70, fill: '#fff', stroke: '#1890ff' } },
-    { tagName: 'rect', selector: 'header', attrs: { x: 0, y: 0, width: 140, height: 22, fill: '#1890ff' } },
-  ],
-});
-graph.addNode({ shape: 'card', stateStyles: { hover: { body: { stroke: '#f00' }, header: { fill: '#fa8c16' } } } });
-
-// DOM 风格操作
-node.getSubElement('header');       // 按 selector 寻址
-node.classList.add('selected');     // className 触发状态
-graph.toJSON();                      // 完整 model 序列化
-```
-
-## 示例（嵌入式 HTML）
+## 示例
 
 | 文件 | 演示 |
 |------|------|
-| `01-basic.html` | Node × 3 + Edge × 3，perimeter 锚点 + 不同 connector |
-| `02-ports.html` | Port 挂载 + ratio 锚点精确定位 |
-| `03-router.html` | normal / orthogonal / manhattan × rounded / smooth 对比 |
-| `04-interaction.html` | 拖拽 + 选中 + 撤销 + 对齐线 + 小地图 |
-| `05-advanced.html` | 滚轮缩放/平移 + 分组 + 对齐线 + 导出 PNG + diamond shape |
-| `06-stencil.html` | Stencil 拖拽创建 + 一键布局 + 小地图拖框导航 |
-| `07-react.html` | `@antv/ge-react` 声明式 `<GraphView>`（props diff） |
-| `08-edit.html` | 拖出连线 + 键盘 + 复制粘贴 + 多选变换 + Resize + Vertex |
-
-## 核心原语
-
-| 模块 | 能力 | 内置 |
-|------|------|------|
-| **Anchor** | 节点 / 线性锚点 | center/top/bottom/left/right/四角/ratio/coordinate/perimeter；edge: ratio/length/mid/segment |
-| **Router** | 控制点 → 路由折线 | normal / orthogonal / manhattan |
-| **Connector** | 折线 → SVG path `d`（含原地 `update`） | normal / polyline / rounded / smooth |
-
-均为纯函数 + 注册表，核心逻辑无 DOM 依赖，单测密集覆盖。
-
-## 测试
-
-```bash
-pnpm test
-```
-
-```
-✓ utils.test.ts       17 tests   几何 / 向量
-✓ anchor.test.ts      16 tests   节点 / 线性锚点 / 注册表
-✓ edge.test.ts        14 tests   Router / Connector / 原地 update
-✓ compute.test.ts      4 tests   computeEdgePoints
-✓ layout.test.ts       7 tests   grid/circular/force/hierarchical
-✓ plugins.test.ts     11 tests   History / closestCell / addClass/removeClass
-✓ shape.test.ts        5 tests   ShapeRegistry 注册/resolve/覆盖
-✓ smoke.test.ts        1 test
-                         75 tests passed
-```
-
-领域元素的渲染行为 + 交互（pan/zoom/Drag/Resize/Dnd 坐标变换）通过 8 个 example 的 Playwright 自动化校验。
-
-## 目录结构
-
-```
-ge/
-├─ packages/
-│  ├─ ge-core/           核心包
-│  │  ├─ src/
-│  │  │  ├─ core/        Cell/Node/Edge/Port/Group/Graph + types/compute
-│  │  │  ├─ shape/       ShapeRegistry + Markup/Selector + builtIn（rect/circle/ellipse/diamond）
-│  │  │  ├─ anchor/      统一锚点（node-anchor / edge-anchor / registry）
-│  │  │  ├─ edge/        router / connector（含 updatePath 原地更新）
-│  │  │  ├─ plugins/     Drag/Resize/Selection/Hover/CreateEdge/Vertex/Keyboard/Clipboard/Transform/History/Scroller/Snapline/Dnd/Minimap
-│  │  │  ├─ layout/      grid/circular/force/hierarchical
-│  │  │  └─ utils/       几何 / 向量
-│  │  └─ __tests__/      Vitest 单测（75 tests）
-│  └─ ge-react/          React 封装（<GraphView> 声明式 diff）
-├─ examples/             嵌入式 HTML（01–08）
-├─ vite.config.ts        examples dev server
-└─ tsconfig.base.json    TS5 strict
-```
-
-## 路线图
-
-- [x] **L0** 工程地基（pnpm / TS5 / tsup / Vite / Vitest）
-- [x] **L1** 核心原语 + 单测（Anchor / Router / Connector / utils）
-- [x] **L2** 领域元素 + Graph + X6 抽象（ShapeRegistry / Markup / Selector / Attrs / Model）
-- [x] **L3** 交互与编辑：Drag / Resize / Selection / Hover / CreateEdge / Vertex / Keyboard / Clipboard / Transform / History / Scroller / Snapline / Group
-- [x] **L4** 生态：序列化 / Minimap（拖框导航）/ Export / Layout / Dnd（坐标校准）/ `@antv/ge-react`（声明式 diff）
-- [ ] 后续：完整 dagre / 更多内置 shape / 性能优化 / API 文档站点
+| `01-basic` | 基础渲染 + perimeter 锚点 |
+| `02-ports` | Port + ratio 锚点 |
+| `03-router` | 路由 × 连接器对比 |
+| `04-interaction` | 拖拽 + 选中 + 撤销 + 小地图 |
+| `05-advanced` | 缩放/平移 + 分组 + 对齐线 + 导出 |
+| `06-stencil` | Stencil 拖拽 + 布局 + 小地图拖框 |
+| `07-react` | React 声明式 GraphView |
+| `08-edit` | 连线 + 键盘 + 复制 + Resize + Rotate + 框选 + Grid |
 
 ## License
 

--- a/examples/08-edit.html
+++ b/examples/08-edit.html
@@ -35,7 +35,7 @@
   <script type="module">
     import {
       Graph, DragPlugin, SelectionPlugin, HistoryPlugin, MinimapPlugin,
-      CreateEdgePlugin, KeyboardPlugin, ClipboardPlugin, TransformPlugin, ResizePlugin, RotatePlugin, VertexPlugin,
+      CreateEdgePlugin, KeyboardPlugin, ClipboardPlugin, TransformPlugin, ResizePlugin, RotatePlugin, GridPlugin, VertexPlugin,
     } from '@ge';
 
     const graph = new Graph({ container: '#app', background: '#fafafa' });
@@ -50,6 +50,7 @@
     graph.use(new TransformPlugin());
     graph.use(new ResizePlugin());
     graph.use(new RotatePlugin());
+    graph.use(new GridPlugin({ type: 'dot' }));
     graph.use(new VertexPlugin());
 
     graph.addNode({ id: 'a', x: 200, y: 240, width: 130, height: 50, fill: '#e6f7ff', stroke: '#1890ff', label: 'A', rotatable: true, resizable: true });

--- a/examples/08-edit.html
+++ b/examples/08-edit.html
@@ -52,7 +52,7 @@
     graph.use(new RotatePlugin());
     graph.use(new VertexPlugin());
 
-    graph.addNode({ id: 'a', x: 200, y: 240, width: 130, height: 50, fill: '#e6f7ff', stroke: '#1890ff', label: 'A', rotatable: true });
+    graph.addNode({ id: 'a', x: 200, y: 240, width: 130, height: 50, fill: '#e6f7ff', stroke: '#1890ff', label: 'A', rotatable: true, resizable: true });
     graph.addNode({ id: 'b', x: 540, y: 180, width: 130, height: 50, label: 'B' });
     graph.addNode({ id: 'c', x: 540, y: 340, width: 130, height: 50, fill: '#f6ffed', stroke: '#52c41a', label: 'C' });
     graph.addEdge({ source: 'a', target: 'b', router: 'orthogonal', connector: 'rounded' });

--- a/examples/08-edit.html
+++ b/examples/08-edit.html
@@ -35,7 +35,7 @@
   <script type="module">
     import {
       Graph, DragPlugin, SelectionPlugin, HistoryPlugin, MinimapPlugin,
-      CreateEdgePlugin, KeyboardPlugin, ClipboardPlugin, TransformPlugin, ResizePlugin, VertexPlugin,
+      CreateEdgePlugin, KeyboardPlugin, ClipboardPlugin, TransformPlugin, ResizePlugin, RotatePlugin, VertexPlugin,
     } from '@ge';
 
     const graph = new Graph({ container: '#app', background: '#fafafa' });
@@ -49,9 +49,10 @@
     const clipboard = graph.use(new ClipboardPlugin());
     graph.use(new TransformPlugin());
     graph.use(new ResizePlugin());
+    graph.use(new RotatePlugin());
     graph.use(new VertexPlugin());
 
-    graph.addNode({ id: 'a', x: 200, y: 240, width: 130, height: 50, fill: '#e6f7ff', stroke: '#1890ff', label: 'A' });
+    graph.addNode({ id: 'a', x: 200, y: 240, width: 130, height: 50, fill: '#e6f7ff', stroke: '#1890ff', label: 'A', rotatable: true });
     graph.addNode({ id: 'b', x: 540, y: 180, width: 130, height: 50, label: 'B' });
     graph.addNode({ id: 'c', x: 540, y: 340, width: 130, height: 50, fill: '#f6ffed', stroke: '#52c41a', label: 'C' });
     graph.addEdge({ source: 'a', target: 'b', router: 'orthogonal', connector: 'rounded' });

--- a/packages/ge-core/src/core/Cell.ts
+++ b/packages/ge-core/src/core/Cell.ts
@@ -30,10 +30,12 @@ export abstract class Cell extends CustomElement<any> {
       this.render();
       this.rendered = true;
     }
+    this.fire('cell:added', { id: this.id, cell: this });
   }
 
   disconnectedCallback(): void {
     this.rendered = false;
+    this.fire('cell:removed', { id: this.id, cell: this });
   }
 
   /** 首次连接时构建渲染元素 */

--- a/packages/ge-core/src/core/Edge.ts
+++ b/packages/ge-core/src/core/Edge.ts
@@ -74,6 +74,7 @@ export class Edge extends Cell {
         lineWidth: s.strokeWidth,
         fill: 'none',
         lineDash: s.lineDash as number[] | undefined,
+        opacity: s.opacity as number | undefined,
       },
     });
     this.appendChild(this.body);
@@ -113,6 +114,9 @@ export class Edge extends Cell {
         break;
       case 'lineDash':
         this.body?.setAttribute('lineDash', newV);
+        break;
+      case 'opacity':
+        this.body?.setAttribute('opacity', newV);
         break;
       default:
         break;

--- a/packages/ge-core/src/core/Edge.ts
+++ b/packages/ge-core/src/core/Edge.ts
@@ -10,7 +10,7 @@ import { Path, Text, type DisplayObject } from '@antv/g-lite';
 import { Cell } from './Cell';
 import { CLASS, type EndpointConfig } from './types';
 import { computeEdgePoints } from './compute';
-import { edgeAnchorMid } from '../anchor/edge-anchor';
+import { edgeAnchorRatio } from '../anchor/edge-anchor';
 import { updatePath, type ConnectorFn, type ConnectorOptions } from '../edge/connector';
 import type { RouterFn } from '../edge/router';
 import type { NodeAnchorFn } from '../anchor/types';
@@ -194,7 +194,7 @@ export class Edge extends Cell {
   /** 把标签定位到路径中点 */
   protected positionLabel(points: Point[]): void {
     if (!this.labelText || points.length === 0) return;
-    const mid = edgeAnchorMid(points);
+    const mid = edgeAnchorRatio(points, { t: ((this.styleProps().labelDistance as number) ?? 0.5) });
     this.labelText.setLocalPosition(mid.x, mid.y);
   }
 

--- a/packages/ge-core/src/core/Edge.ts
+++ b/packages/ge-core/src/core/Edge.ts
@@ -73,6 +73,7 @@ export class Edge extends Cell {
         stroke: s.stroke,
         lineWidth: s.strokeWidth,
         fill: 'none',
+        lineDash: s.lineDash as number[] | undefined,
       },
     });
     this.appendChild(this.body);
@@ -109,6 +110,9 @@ export class Edge extends Cell {
         break;
       case 'strokeWidth':
         this.body?.setAttribute('lineWidth', newV);
+        break;
+      case 'lineDash':
+        this.body?.setAttribute('lineDash', newV);
         break;
       default:
         break;

--- a/packages/ge-core/src/core/Edge.ts
+++ b/packages/ge-core/src/core/Edge.ts
@@ -48,6 +48,7 @@ export class Edge extends Cell {
 
   protected body?: DisplayObject;
   protected endMarker?: Path;
+  protected startMarker?: Path;
   protected labelText?: Text;
   /** 由 Graph 注入的解析器 */
   resolveAnchor?: (name?: string) => NodeAnchorFn;
@@ -65,6 +66,7 @@ export class Edge extends Cell {
   protected render(): void {
     const s = this.styleProps();
     this.endMarker = this.createMarker(s.stroke as string);
+    this.startMarker = (s.startArrow as boolean) ? this.createMarker(s.stroke as string) : undefined;
     this.body = new Path({
       style: {
         d: 'M 0 0',
@@ -99,6 +101,7 @@ export class Edge extends Cell {
       case 'stroke':
         this.body?.setAttribute('stroke', newV);
         this.endMarker?.setAttribute('fill', newV);
+        this.startMarker?.setAttribute('fill', newV);
         break;
       case 'label':
         this.syncLabel();
@@ -146,6 +149,9 @@ export class Edge extends Cell {
     updatePath(this.body, points, connectorFn, opts);
     if (this.endMarker && !this.body.getAttribute('markerEnd')) {
       this.body.setAttribute('markerEnd', this.endMarker);
+    }
+    if (this.startMarker && !this.body.getAttribute('markerStart')) {
+      this.body.setAttribute('markerStart', this.startMarker);
     }
     this.positionLabel(points);
   }

--- a/packages/ge-core/src/core/Graph.ts
+++ b/packages/ge-core/src/core/Graph.ts
@@ -213,6 +213,16 @@ export class Graph extends Canvas {
     throw new Error('[GE] no canvas/svg element found for export');
   }
 
+  /** 导出为 SVG 字符串（含 xmlns，可直接保存 .svg 文件） */
+  toSVGString(): string {
+    const container = this.getConfig().container as HTMLElement;
+    const svg = container.querySelector('svg');
+    if (!svg) return '';
+    const clone = svg.cloneNode(true) as SVGElement;
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    return new XMLSerializer().serializeToString(clone);
+  }
+
   // ---- 序列化 ----
   toJSON(): { nodes: Record<string, unknown>[]; edges: Record<string, unknown>[] } {
     // 直接返回 Cell 的 props model（用户设的所有字段都保留，不漏 data/stateStyles 等）

--- a/packages/ge-core/src/core/Node.ts
+++ b/packages/ge-core/src/core/Node.ts
@@ -290,12 +290,14 @@ export class Node extends Cell {
   }
 
   /** 置顶（DOM 最后 = 最上层渲染） */
-  toFront(): void {
+  toFront(): this {
     this.parentNode?.appendChild(this);
+    return this;
   }
 
   /** 置底（DOM 最前 = 最下层渲染） */
-  toBack(): void {
+  toBack(): this {
     this.parentNode?.insertBefore(this, this.parentNode.firstChild);
+    return this;
   }
 }

--- a/packages/ge-core/src/core/Node.ts
+++ b/packages/ge-core/src/core/Node.ts
@@ -288,4 +288,14 @@ export class Node extends Cell {
       height: (s.height as number) ?? 0,
     };
   }
+
+  /** 置顶（DOM 最后 = 最上层渲染） */
+  toFront(): void {
+    this.parentNode?.appendChild(this);
+  }
+
+  /** 置底（DOM 最前 = 最下层渲染） */
+  toBack(): void {
+    this.parentNode?.insertBefore(this, this.parentNode.firstChild);
+  }
 }

--- a/packages/ge-core/src/core/Node.ts
+++ b/packages/ge-core/src/core/Node.ts
@@ -268,12 +268,22 @@ export class Node extends Cell {
     return this;
   }
 
-  /** 世界坐标包围盒（直接用 x/y/width/height attribute，避免 getBounds 的 root.translate 污染与副作用） */
+  /** 世界坐标包围盒（x/y attribute + parent group 偏移，支持嵌套） */
   getWorldBBox(): BBox {
     const s = this.styleProps();
+    let x = (s.x as number) ?? 0;
+    let y = (s.y as number) ?? 0;
+    // 遍历 parent chain，累加 group 偏移（支持嵌套 group）
+    let p: any = this.parentNode;
+    while (p) {
+      if (typeof p.className === 'string' && p.className.includes('ge-group')) {
+        const ps = p.styleProps?.();
+        if (ps) { x += (ps.x as number) ?? 0; y += (ps.y as number) ?? 0; }
+      }
+      p = p.parentNode;
+    }
     return {
-      x: (s.x as number) ?? 0,
-      y: (s.y as number) ?? 0,
+      x, y,
       width: (s.width as number) ?? 0,
       height: (s.height as number) ?? 0,
     };

--- a/packages/ge-core/src/core/Node.ts
+++ b/packages/ge-core/src/core/Node.ts
@@ -117,6 +117,14 @@ export class Node extends Cell {
     this.fire('node:boundschange');
   }
 
+  /** 应用旋转（angle attribute → setLocalEulerAngles） */
+  protected applyRotation(): void {
+    const s = this.styleProps();
+    const angle = (s.angle as number) ?? 0;
+    this.setLocalEulerAngles(angle);
+    this.fire('node:boundschange');
+  }
+
   attributeChangedCallback(
     name: string | number | symbol,
     oldV: any,
@@ -129,6 +137,9 @@ export class Node extends Cell {
       case 'x':
       case 'y':
         this.applyPosition();
+        break;
+      case 'angle':
+        this.applyRotation();
         break;
       case 'shape':
       case 'width':

--- a/packages/ge-core/src/core/Port.ts
+++ b/packages/ge-core/src/core/Port.ts
@@ -1,18 +1,21 @@
 /**
- * Port —— 节点上的连接端口，挂在 Node 内部，定位为相对 owner 的局部坐标。
+ * Port —— 节点上的连接端口。
+ *
+ * - layout attribute: 'top'/'bottom'/'left'/'right'（自动定位到 owner 边中点）
+ * - 默认 absolute（x/y 局部坐标手动定位）
  */
 import { Circle } from '@antv/g-lite';
 import { Cell } from './Cell';
 import { CLASS } from './types';
 
 export interface PortStyleProps {
-  /** 相对 owner 的局部坐标 */
   x?: number;
   y?: number;
   r?: number;
   fill?: string;
   stroke?: string;
   strokeWidth?: number;
+  layout?: string;
   [key: string]: any;
 }
 
@@ -34,14 +37,28 @@ export class Port extends Cell {
       style: { cx: 0, cy: 0, r: s.r ?? 4, fill: s.fill, stroke: s.stroke, lineWidth: s.strokeWidth },
     });
     this.appendChild(this.body);
-    this.setLocalPosition(s.x as number, s.y as number);
+    this.applyLayout();
+  }
+
+  protected applyLayout(): void {
+    const s = this.styleProps();
+    const layout = (s.layout as string) ?? '';
+    const parent = this.parentNode as any;
+    const pw = (parent?.getAttribute?.('width') as number) ?? 100;
+    const ph = (parent?.getAttribute?.('height') as number) ?? 50;
+    let x = s.x as number, y = s.y as number;
+    if (layout === 'top') { x = pw / 2; y = 0; }
+    else if (layout === 'bottom') { x = pw / 2; y = ph; }
+    else if (layout === 'left') { x = 0; y = ph / 2; }
+    else if (layout === 'right') { x = pw; y = ph / 2; }
+    this.setLocalPosition(x, y);
   }
 
   attributeChangedCallback(name: any, oldV: any, newV: any): void {
     if (oldV === newV || !this.rendered) return;
     const s = this.styleProps();
-    if (name === 'x' || name === 'y') {
-      this.setLocalPosition(s.x as number, s.y as number);
+    if (name === 'x' || name === 'y' || name === 'layout') {
+      this.applyLayout();
     } else if (this.body) {
       if (name === 'r') this.body.setAttribute('r', newV);
       else if (name === 'fill' || name === 'stroke') this.body.setAttribute(name, newV);

--- a/packages/ge-core/src/plugins/ContextMenuPlugin.ts
+++ b/packages/ge-core/src/plugins/ContextMenuPlugin.ts
@@ -1,0 +1,82 @@
+/**
+ * ContextMenuPlugin —— 右键上下文菜单。
+ *
+ * - 右键画布 → 显示自定义菜单（DOM overlay）。
+ * - 菜单项通过构造函数配置（DOM 化，非命令式 API）。
+ * - 点击菜单项触发 action({ target, graph })。
+ */
+import { Plugin } from './plugin';
+
+export interface ContextMenuItem {
+  label: string;
+  action?: (ctx: { target: any; graph: any }) => void;
+  separator?: boolean;
+}
+
+export class ContextMenuPlugin extends Plugin {
+  readonly name = 'contextMenu';
+  private menu?: HTMLDivElement;
+  private items: ContextMenuItem[];
+
+  constructor(items: ContextMenuItem[] = []) {
+    super();
+    this.items = items;
+  }
+
+  init(graph: any): void {
+    super.init(graph);
+    const container = graph.getConfig().container as HTMLElement;
+    if (!container) return;
+    if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
+
+    this.menu = document.createElement('div');
+    this.menu.style.cssText =
+      'position:absolute;background:#fff;border:1px solid #d9d9d9;border-radius:6px;' +
+      'box-shadow:0 2px 8px rgba(0,0,0,.12);padding:4px 0;z-index:20;display:none;' +
+      'min-width:120px;font-size:13px;font-family:system-ui,sans-serif;';
+    container.appendChild(this.menu);
+
+    container.addEventListener('contextmenu', (e: MouseEvent) => {
+      e.preventDefault();
+      const rect = container.getBoundingClientRect();
+      const target = graph.pickNode(e.clientX - rect.left, e.clientY - rect.top);
+      this.show(e.clientX - rect.left, e.clientY - rect.top, target);
+    });
+
+    document.addEventListener('click', () => this.hide());
+  }
+
+  private show(x: number, y: number, target: any): void {
+    if (!this.menu) return;
+    this.menu.innerHTML = '';
+    for (const item of this.items) {
+      if (item.separator) {
+        const sep = document.createElement('div');
+        sep.style.cssText = 'height:1px;background:#e8e8e8;margin:4px 0;';
+        this.menu.appendChild(sep);
+        continue;
+      }
+      const el = document.createElement('div');
+      el.textContent = item.label;
+      el.style.cssText = 'padding:6px 16px;cursor:pointer;white-space:nowrap;';
+      el.addEventListener('mouseenter', () => { el.style.background = '#f5f5f5'; });
+      el.addEventListener('mouseleave', () => { el.style.background = ''; });
+      el.addEventListener('click', () => {
+        item.action?.({ target, graph: this.graph });
+        this.hide();
+      });
+      this.menu.appendChild(el);
+    }
+    this.menu.style.left = x + 'px';
+    this.menu.style.top = y + 'px';
+    this.menu.style.display = 'block';
+  }
+
+  private hide(): void {
+    if (this.menu) this.menu.style.display = 'none';
+  }
+
+  destroy(): void {
+    this.menu?.remove();
+  }
+}

--- a/packages/ge-core/src/plugins/GridPlugin.ts
+++ b/packages/ge-core/src/plugins/GridPlugin.ts
@@ -6,7 +6,7 @@
  */
 import { Plugin } from './plugin';
 
-export interface GridOptions {
+export interface GridPluginOptions {
   /** 网格类型：dot 点阵 / line 网格线 */
   type?: 'dot' | 'line';
   /** 网格间距（世界坐标，默认 20） */
@@ -21,10 +21,10 @@ export interface GridOptions {
 
 export class GridPlugin extends Plugin {
   readonly name = 'grid';
-  private opts: Required<GridOptions>;
+  private opts: Required<GridPluginOptions>;
   private layer?: HTMLDivElement;
 
-  constructor(options: GridOptions = {}) {
+  constructor(options: GridPluginOptions = {}) {
     super();
     this.opts = {
       type: options.type ?? 'dot',

--- a/packages/ge-core/src/plugins/GridPlugin.ts
+++ b/packages/ge-core/src/plugins/GridPlugin.ts
@@ -1,0 +1,88 @@
+/**
+ * GridPlugin —— 画布背景网格。
+ *
+ * - 点阵 / 网格线两种风格。
+ * - 随 pan/zoom 实时更新（background-position/size 跟 panOffset + zoom）。
+ */
+import { Plugin } from './plugin';
+
+export interface GridOptions {
+  /** 网格类型：dot 点阵 / line 网格线 */
+  type?: 'dot' | 'line';
+  /** 网格间距（世界坐标，默认 20） */
+  size?: number;
+  /** 网格颜色 */
+  color?: string;
+  /** 主网格间距倍数（每 N 格一条主线，0 = 无主线） */
+  majorEvery?: number;
+  /** 主网格颜色 */
+  majorColor?: string;
+}
+
+export class GridPlugin extends Plugin {
+  readonly name = 'grid';
+  private opts: Required<GridOptions>;
+  private layer?: HTMLDivElement;
+
+  constructor(options: GridOptions = {}) {
+    super();
+    this.opts = {
+      type: options.type ?? 'dot',
+      size: options.size ?? 20,
+      color: options.color ?? '#e8e8e8',
+      majorEvery: options.majorEvery ?? 5,
+      majorColor: options.majorColor ?? '#d0d0d0',
+    };
+  }
+
+  init(graph: any): void {
+    super.init(graph);
+    const container = graph.getConfig().container as HTMLElement;
+    if (!container) return;
+    if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
+
+    this.layer = document.createElement('div');
+    this.layer.setAttribute('data-ge-grid', 'true');
+    this.layer.style.cssText = 'position:absolute;inset:0;pointer-events:none;z-index:0;';
+    container.insertBefore(this.layer, container.firstChild);
+
+    const update = (): void => this.update();
+    graph.addEventListener('afterrender', update);
+    update();
+  }
+
+  private update(): void {
+    if (!this.layer || !this.graph) return;
+    const zoom = this.graph.getCamera().getZoom() || 1;
+    const pan = this.graph.panOffset;
+    const cfg = this.graph.getConfig();
+    const cx = (cfg.width ?? 800) / 2;
+    const cy = (cfg.height ?? 600) / 2;
+    const { size, color, type, majorEvery, majorColor } = this.opts;
+
+    // 网格在视口的位置（中心缩放公式：viewport = (world + panOffset - center) * zoom + center）
+    // world=0 的视口位置 = (0 + pan - center) * zoom + center = (pan - center) * zoom + center
+    const originX = ((pan.x - cx) * zoom + cx) % (size * zoom);
+    const originY = ((pan.y - cy) * zoom + cy) % (size * zoom);
+    const gridSize = size * zoom;
+
+    if (type === 'dot') {
+      this.layer.style.backgroundImage = `radial-gradient(${color} 1px, transparent 1px)`;
+      this.layer.style.backgroundSize = `${gridSize}px ${gridSize}px`;
+      this.layer.style.backgroundPosition = `${originX}px ${originY}px`;
+    } else {
+      // 网格线
+      const minor = `linear-gradient(${color} 1px, transparent 1px), linear-gradient(90deg, ${color} 1px, transparent 1px)`;
+      this.layer.style.backgroundImage = minor;
+      this.layer.style.backgroundSize = `${gridSize}px ${gridSize}px`;
+      this.layer.style.backgroundPosition = `${originX}px ${originY}px`;
+    }
+    // 确保 graph 的 SVG 在网格之上
+    const svg = this.layer.parentElement?.querySelector('svg');
+    if (svg) svg.style.position = svg.style.position || 'relative';
+  }
+
+  destroy(): void {
+    this.layer?.remove();
+  }
+}

--- a/packages/ge-core/src/plugins/HistoryPlugin.ts
+++ b/packages/ge-core/src/plugins/HistoryPlugin.ts
@@ -1,61 +1,72 @@
 /**
- * HistoryPlugin —— 撤销/重做（command 栈）。
+ * HistoryPlugin —— 撤销/重做（snapshot 模式）。
  *
- * - 自动监听节点拖拽（pointerdown 记录起点，node:dragend 记录终点）压栈。
- * - 提供 undo() / redo() / canUndo() / canRedo()。
- * - 也可手动 push(do, undo) 记录任意操作（增删节点等）。
+ * - 自动监听 pointerdown→pointerup（覆盖拖拽/缩放/旋转）：操作前存 before snapshot，操作后存 after。
+ * - 手动 mark()/commit() 用于结构性操作（addNode/removeNode 等）。
+ * - undo/redo 通过 graph.fromJSON 恢复 snapshot。
  */
-import { Plugin, closestCell } from './plugin';
+import { Plugin } from './plugin';
 
-export interface Command {
-  do: () => void;
-  undo: () => void;
+interface Snapshot {
+  before: any;
+  after: any;
 }
 
 export class HistoryPlugin extends Plugin {
   readonly name = 'history';
-  private undoStack: Command[] = [];
-  private redoStack: Command[] = [];
-  private pending: { id: string; x: number; y: number } | null = null;
+  private undoStack: Snapshot[] = [];
+  private redoStack: Snapshot[] = [];
+  private beforeSnapshot: any = null;
 
   init(graph: any): void {
     super.init(graph);
-
-    graph.addEventListener('pointerdown', (e: any) => {
-      const node = graph.pickNode(e.viewportX, e.viewportY);
-      if (!node) return;
-      this.pending = {
-        id: node.id,
-        x: (node.getAttribute('x') as number) ?? 0,
-        y: (node.getAttribute('y') as number) ?? 0,
-      };
+    // pointerdown：记录 before（拖拽/resize/rotate 前）
+    graph.addEventListener('pointerdown', () => {
+      this.beforeSnapshot = this.snap();
     });
-
-    graph.addEventListener('node:dragend', (e: any) => {
-      if (!this.pending) return;
-      const node = e.target;
-      const from = this.pending;
-      this.pending = null;
-      const to = { id: node.id, x: (node.getAttribute('x') as number) ?? 0, y: (node.getAttribute('y') as number) ?? 0 };
-      if (Math.abs(from.x - to.x) < 0.5 && Math.abs(from.y - to.y) < 0.5) return;
-      this.push({
-        do: () => this.graph.getNode(to.id)?.moveTo(to.x, to.y),
-        undo: () => this.graph.getNode(from.id)?.moveTo(from.x, from.y),
-      });
-    });
+    // pointerup：记录 after，如果不同 push
+    const onUp = (): void => {
+      if (!this.beforeSnapshot) return;
+      const after = this.snap();
+      if (JSON.stringify(after) !== JSON.stringify(this.beforeSnapshot)) {
+        this.pushRaw(this.beforeSnapshot, after);
+      }
+      this.beforeSnapshot = null;
+    };
+    graph.addEventListener('pointerup', onUp);
+    graph.addEventListener('pointerupoutside', onUp);
   }
 
-  /** 手动压入一个命令 */
-  push(cmd: Command): void {
-    this.undoStack.push(cmd);
+  private snap(): any {
+    return this.graph.toJSON();
+  }
+
+  private pushRaw(before: any, after: any): void {
+    this.undoStack.push({ before, after });
     this.redoStack = [];
+    if (this.undoStack.length > 50) this.undoStack.shift(); // 限制栈深度
+  }
+
+  /** 手动标记操作开始（addNode/removeNode 等结构性操作） */
+  mark(): void {
+    this.beforeSnapshot = this.snap();
+  }
+
+  /** 手动提交操作（和 mark 配对） */
+  commit(): void {
+    if (!this.beforeSnapshot) return;
+    const after = this.snap();
+    if (JSON.stringify(after) !== JSON.stringify(this.beforeSnapshot)) {
+      this.pushRaw(this.beforeSnapshot, after);
+    }
+    this.beforeSnapshot = null;
   }
 
   undo(): boolean {
     const cmd = this.undoStack.pop();
     if (!cmd) return false;
     this.redoStack.push(cmd);
-    cmd.undo();
+    this.restore(cmd.before);
     return true;
   }
 
@@ -63,17 +74,16 @@ export class HistoryPlugin extends Plugin {
     const cmd = this.redoStack.pop();
     if (!cmd) return false;
     this.undoStack.push(cmd);
-    cmd.do();
+    this.restore(cmd.after);
     return true;
   }
 
-  canUndo(): boolean {
-    return this.undoStack.length > 0;
+  private restore(data: any): void {
+    this.graph.fromJSON(data);
   }
 
-  canRedo(): boolean {
-    return this.redoStack.length > 0;
-  }
+  canUndo(): boolean { return this.undoStack.length > 0; }
+  canRedo(): boolean { return this.redoStack.length > 0; }
 
   clear(): void {
     this.undoStack = [];

--- a/packages/ge-core/src/plugins/HoverPlugin.ts
+++ b/packages/ge-core/src/plugins/HoverPlugin.ts
@@ -1,10 +1,8 @@
 /**
- * HoverPlugin —— 鼠标悬停高亮（通过 className 触发，样式由 Node 的 stateStyles 配置）。
- *
- * - pointermove 命中检测，进入节点 addClass('hover')，离开 removeClass('hover')。
- * - 不写死任何样式，视觉完全由 stateStyles.hover 决定（Node 自带默认 hover 色）。
+ * HoverPlugin —— 鼠标悬停高亮（节点 + 边）。
+ * pointermove 命中 → addClass('hover')，离开 → removeClass('hover')。
  */
-import { Plugin, closestCell, addClass, removeClass } from './plugin';
+import { Plugin, closestCell, closestEdge, addClass, removeClass } from './plugin';
 
 export class HoverPlugin extends Plugin {
   readonly name = 'hover';
@@ -14,10 +12,12 @@ export class HoverPlugin extends Plugin {
     super.init(graph);
     graph.addEventListener('pointermove', (e: any) => {
       const node = graph.pickNode(e.viewportX, e.viewportY);
-      if (node === this.hovered) return;
+      const edge = node ? null : closestEdge(e.target);
+      const target = node || edge;
+      if (target === this.hovered) return;
       if (this.hovered) removeClass(this.hovered, 'hover');
-      this.hovered = node;
-      if (node) addClass(node, 'hover');
+      this.hovered = target;
+      if (target) addClass(target, 'hover');
     });
   }
 

--- a/packages/ge-core/src/plugins/ResizePlugin.ts
+++ b/packages/ge-core/src/plugins/ResizePlugin.ts
@@ -1,18 +1,27 @@
 /**
- * ResizePlugin —— 节点尺寸调整手柄。
+ * ResizePlugin —— 节点 8 向尺寸调整手柄。
  *
- * - 选中单个节点时，在其右下角显示一个拖拽手柄（DOM overlay）。
- * - 拖拽手柄 → 实时修改节点 width/height（视口 dx/dy 经 zoom 转世界坐标）。
- * - 手柄位置随节点移动 / 画布平移缩放实时更新（afterrender）。
+ * - 选中单个节点 + `resizable: true` 时，显示 8 个手柄（4 角 + 4 边中点）。
+ * - 拖拽手柄 → 实时修改 width/height/x/y（保持对角/对边固定，DOM 化 setAttribute）。
+ * - 手柄随节点移动 / 旋转 / 画布 pan/zoom 实时更新。
  * - 依赖 SelectionPlugin。
  */
 import { Plugin } from './plugin';
 
+const HANDLES = ['nw', 'n', 'ne', 'w', 'e', 'sw', 's', 'se'] as const;
+type Dir = (typeof HANDLES)[number];
+
+const CURSORS: Record<Dir, string> = {
+  nw: 'nwse-resize', n: 'ns-resize', ne: 'nesw-resize',
+  w: 'ew-resize', e: 'ew-resize',
+  sw: 'nesw-resize', s: 'ns-resize', se: 'nwse-resize',
+};
+
 export class ResizePlugin extends Plugin {
   readonly name = 'resize';
-  private handle?: HTMLDivElement;
+  private handles: Record<string, HTMLDivElement> = {};
   private target?: any;
-  private resizing: { startX: number; startY: number; startW: number; startH: number } | null = null;
+  private resizing: { dir: Dir; startX: number; startY: number; ox: number; oy: number; ow: number; oh: number } | null = null;
 
   init(graph: any): void {
     super.init(graph);
@@ -20,67 +29,86 @@ export class ResizePlugin extends Plugin {
     if (!container) return;
     if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
 
-    this.handle = document.createElement('div');
-    this.handle.setAttribute('data-ge-resize', 'true');
-    this.handle.style.cssText =
-      'position:absolute;width:10px;height:10px;background:#1890ff;border:1px solid #fff;' +
-      'border-radius:2px;cursor:nwse-resize;z-index:11;display:none;pointer-events:auto;';
-    container.appendChild(this.handle);
+    for (const dir of HANDLES) {
+      const h = document.createElement('div');
+      h.setAttribute('data-ge-resize', dir);
+      h.style.cssText =
+        `position:absolute;width:8px;height:8px;background:#1890ff;border:1px solid #fff;` +
+        `border-radius:2px;cursor:${CURSORS[dir]};z-index:11;display:none;pointer-events:auto;`;
+      container.appendChild(h);
+      this.handles[dir] = h;
+      h.addEventListener('pointerdown', (e: PointerEvent) => {
+        if (!this.target) return;
+        e.stopPropagation();
+        this.resizing = {
+          dir,
+          startX: e.clientX, startY: e.clientY,
+          ox: this.target.getAttribute('x') as number,
+          oy: this.target.getAttribute('y') as number,
+          ow: this.target.getAttribute('width') as number,
+          oh: this.target.getAttribute('height') as number,
+        };
+      });
+    }
 
-    const update = (): void => this.updateHandle();
+    const update = (): void => this.updateHandles();
     graph.addEventListener('pointerdown', () => setTimeout(update, 0));
     graph.addEventListener('node:dragend', update);
     graph.addEventListener('afterrender', () => {
-      if (this.handle && this.handle.style.display !== 'none') update();
+      if (this.handles['se'] && this.handles['se'].style.display !== 'none') update();
     });
 
-    this.handle.addEventListener('pointerdown', (e: PointerEvent) => {
-      if (!this.target) return;
-      e.stopPropagation();
-      this.resizing = {
-        startX: e.clientX,
-        startY: e.clientY,
-        // 存世界坐标的初始尺寸（不除 zoom），与 dx/dy（世界 delta）单位一致
-        startW: this.target.getAttribute('width') as number,
-        startH: this.target.getAttribute('height') as number,
-      };
-    });
     window.addEventListener('pointermove', (e: PointerEvent) => {
       if (!this.resizing || !this.target) return;
       const zoom = graph.getCamera().getZoom() || 1;
       const dx = (e.clientX - this.resizing.startX) / zoom;
       const dy = (e.clientY - this.resizing.startY) / zoom;
-      this.target.resize(Math.max(20, this.resizing.startW + dx), Math.max(20, this.resizing.startH + dy));
-      this.updateHandle();
+      const { dir, ox, oy, ow, oh } = this.resizing;
+      let x = ox, y = oy, w = ow, h = oh;
+      if (dir.includes('w')) { x = ox + dx; w = ow - dx; }
+      if (dir.includes('e')) { w = ow + dx; }
+      if (dir.includes('n')) { y = oy + dy; h = oh - dy; }
+      if (dir.includes('s')) { h = oh + dy; }
+      // 最小尺寸 20
+      if (w < 20) { w = 20; if (dir.includes('w')) x = ox + ow - 20; }
+      if (h < 20) { h = 20; if (dir.includes('n')) y = oy + oh - 20; }
+      this.target.setAttribute('x', x);
+      this.target.setAttribute('y', y);
+      this.target.setAttribute('width', w);
+      this.target.setAttribute('height', h);
+      this.updateHandles();
     });
-    window.addEventListener('pointerup', () => {
-      this.resizing = null;
-    });
+    window.addEventListener('pointerup', () => { this.resizing = null; });
   }
 
-  private updateHandle(): void {
-    if (!this.handle) return;
+  private updateHandles(): void {
     const sel = (this.graph.getPlugin('selection') as any)?.getSelected?.() ?? [];
-    if (sel.length !== 1) {
-      this.handle.style.display = 'none';
-      this.target = undefined;
-      return;
+    const node = sel.length === 1 ? this.graph.getNode(sel[0]) : null;
+    const show = !!(node && node.getAttribute('resizable'));
+    this.target = show ? node : undefined;
+
+    for (const dir of HANDLES) {
+      const h = this.handles[dir];
+      if (!h) continue;
+      if (!show || !node) { h.style.display = 'none'; continue; }
+      const bb = node.getWorldBBox();
+      const tl = this.graph.canvas2Viewport({ x: bb.x, y: bb.y });
+      const tr = this.graph.canvas2Viewport({ x: bb.x + bb.width, y: bb.y });
+      const bl = this.graph.canvas2Viewport({ x: bb.x, y: bb.y + bb.height });
+      const br = this.graph.canvas2Viewport({ x: bb.x + bb.width, y: bb.y + bb.height });
+      const pos: Record<string, { x: number; y: number }> = {
+        nw: tl, n: { x: (tl.x + tr.x) / 2, y: tl.y }, ne: tr,
+        w: { x: tl.x, y: (tl.y + bl.y) / 2 }, e: { x: tr.x, y: (tr.y + br.y) / 2 },
+        sw: bl, s: { x: (bl.x + br.x) / 2, y: bl.y }, se: br,
+      };
+      const p = pos[dir];
+      h.style.left = p.x - 4 + 'px';
+      h.style.top = p.y - 4 + 'px';
+      h.style.display = 'block';
     }
-    const node = this.graph.getNode(sel[0]);
-    if (!node) {
-      this.handle.style.display = 'none';
-      this.target = undefined;
-      return;
-    }
-    this.target = node;
-    const bb = node.getWorldBBox();
-    const p = this.graph.canvas2Viewport({ x: bb.x + bb.width, y: bb.y + bb.height });
-    this.handle.style.left = (p.x - 5) + 'px';
-    this.handle.style.top = (p.y - 5) + 'px';
-    this.handle.style.display = 'block';
   }
 
   destroy(): void {
-    this.handle?.remove();
+    for (const dir of HANDLES) this.handles[dir]?.remove();
   }
 }

--- a/packages/ge-core/src/plugins/RotatePlugin.ts
+++ b/packages/ge-core/src/plugins/RotatePlugin.ts
@@ -1,0 +1,92 @@
+/**
+ * RotatePlugin —— 节点旋转手柄。
+ *
+ * - 选中单个节点 + `rotatable: true` 时，在节点上方显示旋转手柄（紫色圆柄）。
+ * - 拖拽手柄 → 计算角度 → setAttribute('angle', x)（DOM 化声明式）。
+ * - 手柄位置随节点移动 / 旋转 / 画布 pan/zoom 实时更新（afterrender）。
+ * - 依赖 SelectionPlugin。
+ */
+import { Plugin } from './plugin';
+
+export class RotatePlugin extends Plugin {
+  readonly name = 'rotate';
+  private handle?: HTMLDivElement;
+  private target?: any;
+  private rotating = false;
+
+  init(graph: any): void {
+    super.init(graph);
+    const container = graph.getConfig().container as HTMLElement;
+    if (!container) return;
+
+    this.handle = document.createElement('div');
+    this.handle.setAttribute('data-ge-rotate', 'true');
+    this.handle.style.cssText =
+      'position:absolute;width:12px;height:12px;background:#722ed1;border:2px solid #fff;' +
+      'border-radius:50%;cursor:grab;z-index:11;display:none;pointer-events:auto;';
+    container.appendChild(this.handle);
+
+    const update = (): void => this.updateHandle();
+    graph.addEventListener('pointerdown', () => setTimeout(update, 0));
+    graph.addEventListener('node:dragend', update);
+    graph.addEventListener('afterrender', () => {
+      if (this.handle && this.handle.style.display !== 'none') update();
+    });
+
+    this.handle.addEventListener('pointerdown', (e: PointerEvent) => {
+      if (!this.target) return;
+      e.stopPropagation();
+      this.rotating = true;
+    });
+    const containerRect = () => container.getBoundingClientRect();
+    window.addEventListener('pointermove', (e: PointerEvent) => {
+      if (!this.rotating || !this.target) return;
+      const bb = this.target.getWorldBBox();
+      const centerVp = this.graph.canvas2Viewport({ x: bb.x + bb.width / 2, y: bb.y + bb.height / 2 });
+      const rect = containerRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      // 手柄在上方（-y），0° 朝上，顺时针正：angle = atan2(dx, -dy)
+      const dx = mx - centerVp.x;
+      const dy = my - centerVp.y;
+      const angle = (Math.atan2(dx, -dy) * 180) / Math.PI;
+      this.target.setAttribute('angle', Math.round(angle));
+      this.updateHandle();
+    });
+    window.addEventListener('pointerup', () => {
+      this.rotating = false;
+    });
+  }
+
+  private updateHandle(): void {
+    if (!this.handle) return;
+    const sel = (this.graph.getPlugin('selection') as any)?.getSelected?.() ?? [];
+    if (sel.length !== 1) {
+      this.handle.style.display = 'none';
+      this.target = undefined;
+      return;
+    }
+    const node = this.graph.getNode(sel[0]);
+    if (!node || !node.getAttribute('rotatable')) {
+      this.handle.style.display = 'none';
+      this.target = undefined;
+      return;
+    }
+    this.target = node;
+    // 手柄在节点上方，绕中心旋转 angle（视口空间）
+    const bb = node.getWorldBBox();
+    const centerVp = this.graph.canvas2Viewport({ x: bb.x + bb.width / 2, y: bb.y + bb.height / 2 });
+    const angle = (node.getAttribute('angle') as number) ?? 0;
+    const rad = (angle * Math.PI) / 180;
+    const dist = 30; // 视口 px，手柄距中心
+    const hx = centerVp.x + Math.sin(rad) * dist;
+    const hy = centerVp.y - Math.cos(rad) * dist;
+    this.handle.style.left = hx - 6 + 'px';
+    this.handle.style.top = hy - 6 + 'px';
+    this.handle.style.display = 'block';
+  }
+
+  destroy(): void {
+    this.handle?.remove();
+  }
+}

--- a/packages/ge-core/src/plugins/ScrollerPlugin.ts
+++ b/packages/ge-core/src/plugins/ScrollerPlugin.ts
@@ -50,6 +50,7 @@ export class ScrollerPlugin extends Plugin {
 
     graph.addEventListener('pointerdown', (e: any) => {
       if (!panOnBlank) return;
+      if (e.button === 0) return; // 左键留给框选（SelectionPlugin）
       if (graph.pickNode(e.viewportX, e.viewportY)) return; // 点在节点上交给 Drag
       this.panning = { x: e.viewportX, y: e.viewportY };
     });

--- a/packages/ge-core/src/plugins/SelectionPlugin.ts
+++ b/packages/ge-core/src/plugins/SelectionPlugin.ts
@@ -1,23 +1,35 @@
 /**
- * SelectionPlugin —— 点击选中节点/分组。
+ * SelectionPlugin —— 点击选中 + 空白拖拽框选。
  *
- * - 单击：选中目标，清除其余；点空白：清空。
- * - Shift / Cmd / Ctrl + 点击：多选切换。
- * - 选中通过 node.setAttribute('selected', true)，视觉由 Node 响应。
+ * - 单击节点：选中（Shift/Cmd/Ctrl 多选切换）
+ * - 空白左键拖拽：框选（橡皮筋），释放选中框内节点
+ * - 选中通过 className 'selected' 触发（DOM 风格）
  */
-import { Plugin, closestCell, addClass, removeClass } from './plugin';
+import { Plugin, addClass, removeClass } from './plugin';
 
 export class SelectionPlugin extends Plugin {
   readonly name = 'selection';
   readonly selected = new Set<string>();
+  private rubberEl?: HTMLDivElement;
+  private rubber: { startX: number; startY: number } | null = null;
 
   init(graph: any): void {
     super.init(graph);
+    const container = graph.getConfig().container as HTMLElement;
+    if (container && getComputedStyle(container).position === 'static') container.style.position = 'relative';
+    this.rubberEl = document.createElement('div');
+    this.rubberEl.style.cssText =
+      'position:absolute;border:1px solid #1890ff;background:rgba(24,144,255,.1);z-index:9;display:none;pointer-events:none;';
+    container?.appendChild(this.rubberEl);
+
     graph.addEventListener('pointerdown', (e: any) => {
+      if (e.button !== 0) return; // 只左键
       const cell = graph.pickNode(e.viewportX, e.viewportY);
       const additive = !!(e.shiftKey || e.metaKey || e.ctrlKey);
       if (!cell) {
-        this.clear();
+        // 空白：开始框选
+        this.rubber = { startX: e.viewportX, startY: e.viewportY };
+        if (!additive) this.clear();
         return;
       }
       const id = cell.id;
@@ -29,6 +41,42 @@ export class SelectionPlugin extends Plugin {
         this.select(id);
       }
     });
+
+    graph.addEventListener('pointermove', (e: any) => {
+      if (!this.rubber || !this.rubberEl) return;
+      const x = Math.min(this.rubber.startX, e.viewportX);
+      const y = Math.min(this.rubber.startY, e.viewportY);
+      const w = Math.abs(e.viewportX - this.rubber.startX);
+      const h = Math.abs(e.viewportY - this.rubber.startY);
+      this.rubberEl.style.left = x + 'px';
+      this.rubberEl.style.top = y + 'px';
+      this.rubberEl.style.width = w + 'px';
+      this.rubberEl.style.height = h + 'px';
+      this.rubberEl.style.display = 'block';
+    });
+
+    const end = (e: any): void => {
+      if (!this.rubber || !this.rubberEl) return;
+      this.rubberEl.style.display = 'none';
+      const x1 = Math.min(this.rubber.startX, e.viewportX);
+      const y1 = Math.min(this.rubber.startY, e.viewportY);
+      const x2 = Math.max(this.rubber.startX, e.viewportX);
+      const y2 = Math.max(this.rubber.startY, e.viewportY);
+      this.rubber = null;
+      if (x2 - x1 < 3 && y2 - y1 < 3) return; // 点击（非拖拽）
+      // 框选：视口框 → 世界框 → 选中中心在框内的节点
+      const w1 = graph.viewport2Canvas({ x: x1, y: y1 });
+      const w2 = graph.viewport2Canvas({ x: x2, y: y2 });
+      const minX = Math.min(w1.x, w2.x), maxX = Math.max(w1.x, w2.x);
+      const minY = Math.min(w1.y, w2.y), maxY = Math.max(w1.y, w2.y);
+      for (const n of graph.getNodes() as any[]) {
+        const bb = n.getWorldBBox();
+        const cx = bb.x + bb.width / 2, cy = bb.y + bb.height / 2;
+        if (cx >= minX && cx <= maxX && cy >= minY && cy <= maxY) this.select(n.id);
+      }
+    };
+    graph.addEventListener('pointerup', end);
+    graph.addEventListener('pointerupoutside', end);
   }
 
   select(id: string): void {
@@ -47,5 +95,9 @@ export class SelectionPlugin extends Plugin {
 
   getSelected(): string[] {
     return [...this.selected];
+  }
+
+  destroy(): void {
+    this.rubberEl?.remove();
   }
 }

--- a/packages/ge-core/src/plugins/TooltipPlugin.ts
+++ b/packages/ge-core/src/plugins/TooltipPlugin.ts
@@ -1,0 +1,79 @@
+/**
+ * TooltipPlugin —— 悬停提示。
+ *
+ * - 鼠标悬停节点 → 显示 tooltip（DOM overlay）。
+ * - tooltip 内容：node.getAttribute('tooltip') 或 node.getData() 或 node.id。
+ * - 移开自动隐藏。
+ */
+import { Plugin } from './plugin';
+
+export interface TooltipOptions {
+  /** 自定义内容生成（默认用 tooltip attribute 或 id） */
+  content?: (target: any) => string;
+  /** 偏移（px） */
+  offset?: number;
+}
+
+export class TooltipPlugin extends Plugin {
+  readonly name = 'tooltip';
+  private el?: HTMLDivElement;
+  private opts: Required<TooltipOptions>;
+  private currentTarget: any = null;
+
+  constructor(options: TooltipOptions = {}) {
+    super();
+    this.opts = {
+      content: options.content ?? ((t: any) => t.getAttribute('tooltip') || t.id || ''),
+      offset: options.offset ?? 12,
+    };
+  }
+
+  init(graph: any): void {
+    super.init(graph);
+    const container = graph.getConfig().container as HTMLElement;
+    if (!container) return;
+    if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
+
+    this.el = document.createElement('div');
+    this.el.style.cssText =
+      'position:absolute;background:rgba(0,0,0,.75);color:#fff;padding:4px 8px;border-radius:4px;' +
+      'font-size:12px;font-family:system-ui,sans-serif;pointer-events:none;z-index:21;display:none;' +
+      'white-space:nowrap;max-width:300px;';
+    container.appendChild(this.el);
+
+    let throttle = false;
+    graph.addEventListener('pointermove', (e: any) => {
+      if (throttle) return;
+      throttle = true;
+      requestAnimationFrame(() => { throttle = false; });
+      const node = graph.pickNode(e.viewportX, e.viewportY);
+      if (node) this.show(node, e.viewportX, e.viewportY);
+      else this.hide();
+    });
+    graph.addEventListener('pointerleave', () => this.hide());
+  }
+
+  private show(target: any, x: number, y: number): void {
+    if (!this.el || target === this.currentTarget) {
+      if (this.el && target === this.currentTarget) {
+        this.el.style.left = x + this.opts.offset + 'px';
+        this.el.style.top = y + this.opts.offset + 'px';
+      }
+      return;
+    }
+    this.currentTarget = target;
+    this.el.textContent = this.opts.content(target);
+    this.el.style.left = x + this.opts.offset + 'px';
+    this.el.style.top = y + this.opts.offset + 'px';
+    this.el.style.display = 'block';
+  }
+
+  private hide(): void {
+    if (this.el) this.el.style.display = 'none';
+    this.currentTarget = null;
+  }
+
+  destroy(): void {
+    this.el?.remove();
+  }
+}

--- a/packages/ge-core/src/plugins/VertexPlugin.ts
+++ b/packages/ge-core/src/plugins/VertexPlugin.ts
@@ -74,6 +74,14 @@ export class VertexPlugin extends Plugin {
 
   private bindDrag(h: HTMLDivElement, idx: number): void {
     let start: { cx: number; cy: number; wp: Point } | null = null;
+    h.addEventListener('dblclick', (e: MouseEvent) => {
+      e.stopPropagation();
+      if (!this.activeEdge) return;
+      const wps = (((this.activeEdge.getAttribute('waypoints') as Point[]) || []) as Point[]).slice();
+      wps.splice(idx, 1);
+      this.activeEdge.setAttribute('waypoints', wps);
+      this.syncHandles();
+    });
     h.addEventListener('pointerdown', (e: PointerEvent) => {
       if (!this.activeEdge) return;
       e.stopPropagation();

--- a/packages/ge-core/src/plugins/index.ts
+++ b/packages/ge-core/src/plugins/index.ts
@@ -12,4 +12,5 @@ export { ClipboardPlugin } from './ClipboardPlugin';
 export { TransformPlugin } from './TransformPlugin';
 export { HoverPlugin } from './HoverPlugin';
 export { ResizePlugin } from './ResizePlugin';
+export { RotatePlugin } from './RotatePlugin';
 export { VertexPlugin } from './VertexPlugin';

--- a/packages/ge-core/src/plugins/index.ts
+++ b/packages/ge-core/src/plugins/index.ts
@@ -14,4 +14,5 @@ export { HoverPlugin } from './HoverPlugin';
 export { ResizePlugin } from './ResizePlugin';
 export { RotatePlugin } from './RotatePlugin';
 export { GridPlugin, type GridPluginOptions } from './GridPlugin';
+export { ContextMenuPlugin, type ContextMenuItem } from './ContextMenuPlugin';
 export { VertexPlugin } from './VertexPlugin';

--- a/packages/ge-core/src/plugins/index.ts
+++ b/packages/ge-core/src/plugins/index.ts
@@ -1,7 +1,7 @@
 export * from './plugin';
 export { DragPlugin } from './DragPlugin';
 export { SelectionPlugin } from './SelectionPlugin';
-export { HistoryPlugin, type Command } from './HistoryPlugin';
+export { HistoryPlugin } from './HistoryPlugin';
 export { MinimapPlugin } from './MinimapPlugin';
 export { ScrollerPlugin, type ScrollerOptions } from './ScrollerPlugin';
 export { SnaplinePlugin, type SnaplineOptions } from './SnaplinePlugin';

--- a/packages/ge-core/src/plugins/index.ts
+++ b/packages/ge-core/src/plugins/index.ts
@@ -13,5 +13,5 @@ export { TransformPlugin } from './TransformPlugin';
 export { HoverPlugin } from './HoverPlugin';
 export { ResizePlugin } from './ResizePlugin';
 export { RotatePlugin } from './RotatePlugin';
-export { GridPlugin, type GridOptions } from './GridPlugin';
+export { GridPlugin, type GridPluginOptions } from './GridPlugin';
 export { VertexPlugin } from './VertexPlugin';

--- a/packages/ge-core/src/plugins/index.ts
+++ b/packages/ge-core/src/plugins/index.ts
@@ -13,4 +13,5 @@ export { TransformPlugin } from './TransformPlugin';
 export { HoverPlugin } from './HoverPlugin';
 export { ResizePlugin } from './ResizePlugin';
 export { RotatePlugin } from './RotatePlugin';
+export { GridPlugin, type GridOptions } from './GridPlugin';
 export { VertexPlugin } from './VertexPlugin';

--- a/packages/ge-core/src/plugins/index.ts
+++ b/packages/ge-core/src/plugins/index.ts
@@ -15,4 +15,5 @@ export { ResizePlugin } from './ResizePlugin';
 export { RotatePlugin } from './RotatePlugin';
 export { GridPlugin, type GridPluginOptions } from './GridPlugin';
 export { ContextMenuPlugin, type ContextMenuItem } from './ContextMenuPlugin';
+export { TooltipPlugin, type TooltipOptions } from './TooltipPlugin';
 export { VertexPlugin } from './VertexPlugin';

--- a/packages/ge-core/src/shape/builtIn.ts
+++ b/packages/ge-core/src/shape/builtIn.ts
@@ -53,7 +53,27 @@ export const diamondShape: ShapeDefinition = {
   },
 };
 
-export const builtInShapes: ShapeDefinition[] = [rectShape, circleShape, ellipseShape, diamondShape];
+export const triangleShape: ShapeDefinition = {
+  name: 'triangle',
+  create: (s) => {
+    const w = s.width as number;
+    const h = s.height as number;
+    const d = `M ${w / 2} 0 L ${w} ${h} L 0 ${h} Z`;
+    return new Path({ style: { d, fill: s.fill, stroke: s.stroke, lineWidth: s.strokeWidth } });
+  },
+};
+
+export const hexagonShape: ShapeDefinition = {
+  name: 'hexagon',
+  create: (s) => {
+    const w = s.width as number;
+    const h = s.height as number;
+    const d = `M ${w * 0.25} 0 L ${w * 0.75} 0 L ${w} ${h / 2} L ${w * 0.75} ${h} L ${w * 0.25} ${h} L 0 ${h / 2} Z`;
+    return new Path({ style: { d, fill: s.fill, stroke: s.stroke, lineWidth: s.strokeWidth } });
+  },
+};
+
+export const builtInShapes: ShapeDefinition[] = [rectShape, circleShape, ellipseShape, diamondShape, triangleShape, hexagonShape];
 
 import { ShapeRegistry } from './registry';
 

--- a/packages/ge-core/src/shape/builtIn.ts
+++ b/packages/ge-core/src/shape/builtIn.ts
@@ -73,7 +73,17 @@ export const hexagonShape: ShapeDefinition = {
   },
 };
 
-export const builtInShapes: ShapeDefinition[] = [rectShape, circleShape, ellipseShape, diamondShape, triangleShape, hexagonShape];
+export const parallelogramShape: ShapeDefinition = {
+  name: 'parallelogram',
+  create: (s) => {
+    const w = s.width as number;
+    const h = s.height as number;
+    const d = `M ${w * 0.15} 0 L ${w} 0 L ${w * 0.85} ${h} L 0 ${h} Z`;
+    return new Path({ style: { d, fill: s.fill, stroke: s.stroke, lineWidth: s.strokeWidth } });
+  },
+};
+
+export const builtInShapes: ShapeDefinition[] = [rectShape, circleShape, ellipseShape, diamondShape, triangleShape, hexagonShape, parallelogramShape];
 
 import { ShapeRegistry } from './registry';
 

--- a/packages/ge-core/src/shape/builtIn.ts
+++ b/packages/ge-core/src/shape/builtIn.ts
@@ -83,7 +83,18 @@ export const parallelogramShape: ShapeDefinition = {
   },
 };
 
-export const builtInShapes: ShapeDefinition[] = [rectShape, circleShape, ellipseShape, diamondShape, triangleShape, hexagonShape, parallelogramShape];
+export const cylinderShape: ShapeDefinition = {
+  name: 'cylinder',
+  create: (s) => {
+    const w = s.width as number;
+    const h = s.height as number;
+    const ry = h * 0.1; // 椭圆半高
+    const d = `M 0 ${ry} A ${w / 2} ${ry} 0 0 0 ${w} ${ry} L ${w} ${h - ry} A ${w / 2} ${ry} 0 0 1 0 ${h - ry} L 0 ${ry} Z M 0 ${ry} A ${w / 2} ${ry} 0 0 1 ${w} ${ry}`;
+    return new Path({ style: { d, fill: s.fill, stroke: s.stroke, lineWidth: s.strokeWidth } });
+  },
+};
+
+export const builtInShapes: ShapeDefinition[] = [rectShape, circleShape, ellipseShape, diamondShape, triangleShape, hexagonShape, parallelogramShape, cylinderShape];
 
 import { ShapeRegistry } from './registry';
 


### PR DESCRIPTION
## 概述

本 PR 是 `rewrite` 分支的**从零重写**版本：以 AntV/G（g-lite）的 CustomElement / Document 为唯一基座，把 g-lite 当作「浏览器引擎」，GE 是跑在它之上的「图编辑 DOM 规范」——不重建任何平行系统。

### 设计哲学

| 维度 | 决策 |
|------|------|
| **数据结构** | 借鉴 X6（Markup/Selector/Attrs/shape 声明式模型） |
| **交互 API** | 靠拢 DOM（setAttribute/appendChild/addEventListener/classList/querySelector） |

```ts
// 创建 = new + appendChild
graph.appendChild(new Node({ shape: 'rect', x: 100, y: 100, label: 'A' }));

// 变换 = setAttribute（响应式）
node.setAttribute('angle', 45);        // 旋转
node.setAttribute('width', 200);       // 缩放

// 工具 = 声明式 attribute（不用 addTools）
node.setAttribute('resizable', true);  // → 选中时显示 8 向手柄
node.setAttribute('rotatable', true);  // → 选中时显示旋转手柄

// 事件 = DOM 冒泡
graph.addEventListener('cell:added', fn);
graph.addEventListener('node:dragend', fn);
```

---

## 功能清单

### 内置 Shape（8）

`rect` / `circle` / `ellipse` / `diamond` / `triangle` / `hexagon` / `parallelogram` / `cylinder`

### 插件（19）

| 插件 | 能力 |
|------|------|
| **Drag** | 节点拖拽移动（delta 抵消坐标偏差） |
| **Resize** | 8 向尺寸手柄（4 角 + 4 边，保持对角固定，`resizable` 声明式） |
| **Rotate** | 旋转手柄（`rotatable` 声明式，`angle` attribute 驱动） |
| **Selection** | 点击选中 + 空白左键拖拽框选（Shift 多选） |
| **Hover** | 节点 + 边悬停高亮（className 触发，stateStyles 配置） |
| **CreateEdge** | Alt + 拖出连线 |
| **Vertex** | 边路径控制点（双击边添加 waypoint，双击控制点删除） |
| **Keyboard** | Delete 删除 |
| **Clipboard** | 复制 / 粘贴 / 克隆 |
| **Transform** | 多选整体平移 |
| **History** | snapshot 模式 undo/redo（覆盖 drag/resize/rotate + mark/commit） |
| **Scroller** | 滚轮缩放 + 中/右键平移 |
| **Snapline** | 对齐辅助线 |
| **Group** | 分组嵌套（embed + getWorldBBox 含 parent offset） |
| **Dnd** | Stencil 拖拽创建（DOM 校准，pan/zoom 后精确） |
| **Minimap** | 缩略导航（拖框平移，框大小恒定） |
| **Grid** | 背景网格（点阵/网格线，pan/zoom 感知） |
| **ContextMenu** | 右键自定义菜单 |
| **Tooltip** | 悬停提示（throttled） |

### 边能力

- **Router**：normal / orthogonal / manhattan（Z 形）
- **Connector**：normal / rounded / smooth
- **双向箭头**：`startArrow: true`（markerStart + markerEnd）
- **标签定位**：`labelDistance` 0-1 沿路径比例
- **虚线/透明**：`lineDash` / `opacity`

### 节点能力

- 旋转（`angle`）、缩放（`width`/`height`）、z-order（`toFront()`/`toBack()`）
- Port 自动布局（`layout: 'top'/'bottom'/'left'/'right'`）
- 状态样式（`stateStyles` 按 selector 粒度）

### 坐标变换

GE 自建 2D 坐标层（panOffset + 中心缩放公式），绕过 g-lite SVG camera 的 3D 投影不一致问题：
- pan = `root.translate`（2D，不污染 scene graph）
- zoom = `camera.setZoom`（线性 scale）
- 坐标转换公式：`viewport = (world + panOffset - center) × zoom + center`
- 自定义命中：`pickNode`（viewport2Canvas + worldBBox，不用 g-lite 3D hit test）

### X6 抽象层

- **ShapeRegistry**：shape 可注册（8 内置 + 自定义）
- **Markup + Selector**：声明式子元素（`getSubElement('body')` 寻址）
- **Attrs**：selector 粒度 stateStyles（`{ hover: { body: { stroke }, label: { fill } } }`）
- **Model**：Cell `props` 自动同步（toJSON 完整，不漏字段）

### 数据 / 导出

- `toJSON()` / `fromJSON()`（完整序列化往返）
- `toDataURL()`（PNG / SVG data URL）
- `toSVGString()`（纯 SVG 字符串）
- `applyLayout()`（grid / circular / force / hierarchical）

### React 封装

`@antv/ge-react` 声明式 `<GraphView>`（props 变化 → 按 id diff 自动同步：增/删/改）

---

## 示例

8 个嵌入式 HTML example（01-08），覆盖基础渲染 → 交互 → 高级 → Stencil+布局 → React → 编辑器全功能。全部通过 Playwright 自动化校验。

---

## 质量

- **tsc**：0 error
- **单元测试**：75 tests（utils/anchor/edge/compute/layout/plugins/shape/smoke）
- **回归**：8 example Playwright 全绿
- **坐标验证**：pan/zoom/minimap 后 Dnd 放置位置与鼠标精确对齐（DOM 校准 + 中心缩放公式）

---

## 关键技术决策

1. **不用 camera.setPosition 做 pan**：g-lite SVG 的 camera 是 3D 透视投影，setPosition 后坐标转换与渲染不一致。改用 `root.translate`（2D）+ panOffset。
2. **不用 e.target 做 hit test**：g-lite 命中不识别 root.translate。自定义 `pickNode`（viewport2Canvas + worldBBox）。
3. **工具不用 addTools**：声明式 `setAttribute('resizable'/'rotatable')`，选中时插件读 attribute 渲染手柄。
4. **Model 不独立类**：CustomElement 的 attribute/props 即 Model，attributeChangedCallback 即监听。
5. **箭头尖端在 (0,0)**：g-lite markerEnd 的 translate = 路径终点，marker d 尖端设在 (0,0) 使箭头贴 target 边缘不伸入节点。
6. **getWorldBBox 用 attribute**：不调 g-lite getBounds（有副作用 + root.translate 污染），直接用 x/y/width/height + parent group offset。